### PR TITLE
feat: add command to initalize users in db

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Discord bot to aid with challenges
 
+## Setup
+
+It is recommended that a new role is made for the bot that has admin permissions, so it can access everything it needs.
+If that is too high, experiment with the right permissions until it works correctly.
+
 ## Commands
 
 ```text

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const { loadEvents } = require('./utils/event-loader');
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent
   ]


### PR DESCRIPTION
The required DB to perform migration might not have the users required. This adds a new command that can be used to initialize it with 0'd out data.